### PR TITLE
Use newer version of node docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:argon
+FROM node:9
 
 ARG hubot_owner
 ARG hubot_description


### PR DESCRIPTION
New yeoman requires Node.js >= Boron. It solves the issue #68 with building a docker image.